### PR TITLE
Refactor to put as much code in the common module as possible.

### DIFF
--- a/api-update/antivirus/src/main/scala/uk/gov/nationalarchives/api/update/antivirus/AntivirusUpdate.scala
+++ b/api-update/antivirus/src/main/scala/uk/gov/nationalarchives/api/update/antivirus/AntivirusUpdate.scala
@@ -1,75 +1,20 @@
 package uk.gov.nationalarchives.api.update.antivirus
 
-import java.net.URI
-
 import com.amazonaws.services.lambda.runtime.Context
 import com.amazonaws.services.lambda.runtime.events.SQSEvent
-import com.typesafe.config.ConfigFactory
-import graphql.codegen.AddAntivirusMetadata.AddAntivirusMetadata
+import graphql.codegen.AddAntivirusMetadata.AddAntivirusMetadata.{Data, Variables, document}
 import graphql.codegen.types.AddAntivirusMetadataInput
-import io.circe
 import io.circe.generic.auto._
-import io.circe.parser.decode
-import software.amazon.awssdk.regions.Region
-import software.amazon.awssdk.services.sqs.SqsClient
-import uk.gov.nationalarchives.api.update.common.{ApiUpdate, ResponseProcessor, SQSUpdate}
-import uk.gov.nationalarchives.tdr.GraphQLClient
-import uk.gov.nationalarchives.tdr.keycloak.KeycloakUtils
-import software.amazon.awssdk.http.apache.ApacheHttpClient
+import uk.gov.nationalarchives.api.update.common.Processor
 
 import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.duration._
-import scala.concurrent.{Await, Future}
-import scala.jdk.CollectionConverters._
 import scala.language.postfixOps
 
-class AntivirusUpdate {
-
-  case class BodyWithReceiptHandle(body: String, recieptHandle: String)
-
-  case class InputWithReceiptHandle(input: AddAntivirusMetadataInput, receiptHandle: String)
+class AntivirusUpdate  {
 
   def update(event: SQSEvent, context: Context): Seq[String] = {
-
-    val configFactory = ConfigFactory.load
-    val inputWithReceiptHandleOrErrors: List[Either[circe.Error, InputWithReceiptHandle]] = event.getRecords.asScala
-      .map(r => BodyWithReceiptHandle(r.getBody, r.getReceiptHandle))
-      .map(bodyWithReceiptHandle => {
-        decode[AddAntivirusMetadataInput](bodyWithReceiptHandle.body)
-          .map(avUpdates => InputWithReceiptHandle(avUpdates, bodyWithReceiptHandle.recieptHandle))
-      }).toList
-
-    val apiUpdate = ApiUpdate()
-    val client = new GraphQLClient[AddAntivirusMetadata.Data, AddAntivirusMetadata.Variables](configFactory.getString("url.api"))
-    val keycloakUtils = KeycloakUtils(configFactory.getString("url.auth"))
-    val endpoint = configFactory.getString("sqs.endpoint")
-
-    val httpClient = ApacheHttpClient.builder.build
-    val sqsClient: SqsClient = SqsClient.builder()
-      .region(Region.EU_WEST_2)
-      .endpointOverride(new URI(endpoint))
-      .httpClient(httpClient)
-      .build()
-    val sqsUpdate = SQSUpdate(sqsClient)
-
-
-    def processInput(inputWithReceiptHandle: InputWithReceiptHandle): Future[Either[String, String]] = {
-      val avInput = inputWithReceiptHandle.input
-      val response: Future[Either[String, AddAntivirusMetadata.Data]] =
-        apiUpdate.send(keycloakUtils, client, AddAntivirusMetadata.document, AddAntivirusMetadata.Variables(avInput))
-      response.map {
-        case Right(_) =>
-          sqsUpdate.deleteSqsMessage(configFactory.getString("sqs.url"), inputWithReceiptHandle.receiptHandle)
-          Right(s"${avInput.fileId} was successful")
-        case Left(e) => Left(s"${avInput.fileId} failed with error $e")
-      }
-    }
-
-    val responses: Seq[Future[Either[String, String]]] = inputWithReceiptHandleOrErrors.map {
-      case Right(inputWithReceiptHandle) => processInput(inputWithReceiptHandle)
-      case Left(err) => Future.successful(Left(err.getMessage))
-    }
-
-    Await.result(ResponseProcessor().process(Future.sequence(responses)), 10 seconds)
+    val processor = new Processor[AddAntivirusMetadataInput, Data, Variables](document, i => Variables(i))
+    processor.process(event)
   }
+
 }

--- a/api-update/common/src/main/scala/uk/gov/nationalarchives/api/update/common/Processor.scala
+++ b/api-update/common/src/main/scala/uk/gov/nationalarchives/api/update/common/Processor.scala
@@ -1,0 +1,53 @@
+package uk.gov.nationalarchives.api.update.common
+
+import com.amazonaws.services.lambda.runtime.events.SQSEvent
+import com.typesafe.config.{Config, ConfigFactory}
+import io.circe
+import io.circe.parser.decode
+import io.circe.{Decoder, Encoder}
+import sangria.ast.Document
+import uk.gov.nationalarchives.tdr.GraphQLClient
+import uk.gov.nationalarchives.tdr.keycloak.KeycloakUtils
+
+import scala.concurrent.duration._
+import scala.concurrent.{Await, ExecutionContext, Future}
+import scala.jdk.CollectionConverters._
+import scala.language.postfixOps
+
+class ProcessorFunction[Input, Data, Variables](document: Document, variablesFn: Input => Variables)(implicit val excecutionContext: ExecutionContext, val decoder: Decoder[Input], val dataDecoder: Decoder[Data], val variablesEncoder: Encoder[Variables]) {
+  case class InputWithReceiptHandle(input: Input, receiptHandle: String)
+  val configFactory: Config = ConfigFactory.load
+  val apiUpdate: ApiUpdate = ApiUpdate()
+  val keycloakUtils: KeycloakUtils = KeycloakUtils(configFactory.getString("url.auth"))
+
+  case class BodyWithReceiptHandle(body: String, recieptHandle: String)
+
+  def processInput(inputWithReceiptHandle: InputWithReceiptHandle): Future[Either[String, String]] = {
+    val client = new GraphQLClient[Data, Variables](configFactory.getString("url.api"))
+    val input = inputWithReceiptHandle.input
+    val response: Future[Either[String, Data]] =
+      apiUpdate.send[Data, Variables](keycloakUtils, client, document, variablesFn(input))
+    response.map {
+      case Right(_) =>
+        SQSUpdate().deleteSqsMessage(configFactory.getString("sqs.url"), inputWithReceiptHandle.receiptHandle)
+        Right(s"$input was successful")
+      case Left(e) => Left(s"$input failed with error $e")
+    }
+  }
+  def process(event: SQSEvent): Seq[String] = {
+    val inputWithReceiptHandleOrErrors: List[Either[circe.Error, InputWithReceiptHandle]] = event.getRecords.asScala
+      .map(r => BodyWithReceiptHandle(r.getBody, r.getReceiptHandle))
+      .map(bodyWithReceiptHandle => {
+        decode[Input](bodyWithReceiptHandle.body)
+          .map(avUpdates => InputWithReceiptHandle(avUpdates, bodyWithReceiptHandle.recieptHandle))
+      }).toList
+
+    val responses: Seq[Future[Either[String, String]]] = inputWithReceiptHandleOrErrors.map {
+      case Right(inputWithReceiptHandle) => processInput(inputWithReceiptHandle)
+      case Left(err) => Future.successful(Left(err.getMessage))
+    }
+
+    Await.result(ResponseProcessor().process(Future.sequence(responses)), 10 seconds)
+  }
+
+}

--- a/api-update/common/src/main/scala/uk/gov/nationalarchives/api/update/common/Processor.scala
+++ b/api-update/common/src/main/scala/uk/gov/nationalarchives/api/update/common/Processor.scala
@@ -14,7 +14,7 @@ import scala.concurrent.{Await, ExecutionContext, Future}
 import scala.jdk.CollectionConverters._
 import scala.language.postfixOps
 
-class ProcessorFunction[Input, Data, Variables](document: Document, variablesFn: Input => Variables)(implicit val excecutionContext: ExecutionContext, val decoder: Decoder[Input], val dataDecoder: Decoder[Data], val variablesEncoder: Encoder[Variables]) {
+class Processor[Input, Data, Variables](document: Document, variablesFn: Input => Variables)(implicit val excecutionContext: ExecutionContext, val decoder: Decoder[Input], val dataDecoder: Decoder[Data], val variablesEncoder: Encoder[Variables]) {
   case class InputWithReceiptHandle(input: Input, receiptHandle: String)
   val configFactory: Config = ConfigFactory.load
   val apiUpdate: ApiUpdate = ApiUpdate()

--- a/api-update/common/src/main/scala/uk/gov/nationalarchives/api/update/common/SQSUpdate.scala
+++ b/api-update/common/src/main/scala/uk/gov/nationalarchives/api/update/common/SQSUpdate.scala
@@ -1,5 +1,10 @@
 package uk.gov.nationalarchives.api.update.common
 
+import java.net.URI
+
+import com.typesafe.config.ConfigFactory
+import software.amazon.awssdk.http.apache.ApacheHttpClient
+import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.sqs.SqsClient
 import software.amazon.awssdk.services.sqs.model.DeleteMessageRequest
 
@@ -13,5 +18,14 @@ class SQSUpdate(sqsClient: SqsClient) {
 }
 
 object SQSUpdate {
-  def apply(sqsClient: SqsClient): SQSUpdate = new SQSUpdate(sqsClient)
+  def apply(): SQSUpdate = {
+    val configFactory = ConfigFactory.load
+    val httpClient = ApacheHttpClient.builder.build
+    val sqsClient: SqsClient = SqsClient.builder()
+      .region(Region.EU_WEST_2)
+      .endpointOverride(new URI(configFactory.getString("sqs.endpoint")))
+      .httpClient(httpClient)
+      .build()
+    new SQSUpdate(sqsClient)
+  }
 }

--- a/api-update/common/src/test/resources/json/input_processor_test.json
+++ b/api-update/common/src/test/resources/json/input_processor_test.json
@@ -1,0 +1,1 @@
+{"test":  "a test string"}

--- a/api-update/common/src/test/scala/uk/gov/nationalarchives/api/update/common/SQSUpdateTest.scala
+++ b/api-update/common/src/test/scala/uk/gov/nationalarchives/api/update/common/SQSUpdateTest.scala
@@ -10,7 +10,7 @@ import uk.gov.nationalarchives.api.update.common.utils.ExternalServicesTest
 class SQSUpdateTest extends ExternalServicesTest with MockitoSugar  {
   "The deleteMessage method" should "delete a message" in {
     val sqsClient = Mockito.mock(classOf[SqsClient])
-    val sqsUpdate = SQSUpdate(sqsClient)
+    val sqsUpdate = SQSUpdate()
     val queueUrl = "testqueue"
     val receiptHandle = "testreceipthandle"
     val captor: ArgumentCaptor[DeleteMessageRequest] = ArgumentCaptor.forClass(classOf[DeleteMessageRequest])


### PR DESCRIPTION
For new lambdas, it should be possible to create a new instance of the
Processor class with the correct type parameters and call process.

This may be a way in the future to have a single lambda which does all
of the api updates but for now, this will make writing the separate ones
easier.